### PR TITLE
Add mobile layout with bottom navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import LoginSection from './Login'
 import Register from './Register'
 import UserProfile from './components/UserProfile'
 import AppMenu from './components/Menu'
+import MobileMenu from './components/MobileMenu'
 import { logout } from './services/auth'
 import { Button } from 'antd'
 import { BulbOutlined } from '@ant-design/icons'
@@ -17,6 +18,13 @@ const App = () => {
   const [user, setUser] = useState(null)
   const [isRegistering, setIsRegistering] = useState(false)
   const [isDarkMode, setIsDarkMode] = useState(false)
+  const [isMobile, setIsMobile] = useState(window.innerWidth <= 768)
+
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth <= 768)
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
 
   useEffect(() => {
     const auth = getAuth()
@@ -46,12 +54,14 @@ const App = () => {
 
   return (
     <Router>
-      <div className="App">
+      <div className={`App ${isMobile ? 'mobile-layout' : 'desktop-layout'}`}>
         {user ? (
           <>
-            <div className="sidebar">
-              <AppMenu />
-            </div>
+            {!isMobile && (
+              <div className="sidebar">
+                <AppMenu />
+              </div>
+            )}
             <div className="content">
               <div className="header">
                 <UserProfile user={user} onLogout={handleLogout} />
@@ -72,6 +82,7 @@ const App = () => {
                 <Route path="*" element={<Navigate to="/orcamento" />} />
               </Routes>
             </div>
+            {isMobile && <MobileMenu />}
           </>
         ) : (
           <div className="content">

--- a/src/components/MobileMenu.js
+++ b/src/components/MobileMenu.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Menu } from 'antd'
+import { PieChartOutlined, LineChartOutlined } from '@ant-design/icons'
+import { Link, useLocation } from 'react-router-dom'
+
+const items = [
+  {
+    key: '1',
+    icon: <PieChartOutlined />,
+    label: <Link to="/orcamento">Orçamento</Link>
+  },
+  {
+    key: '2',
+    icon: <LineChartOutlined />,
+    label: <Link to="/media-mensal">Média Mensal</Link>
+  }
+]
+
+const MobileMenu = () => {
+  const location = useLocation()
+  const selectedKey = location.pathname.includes('media-mensal') ? '2' : '1'
+
+  return (
+    <div className="mobile-menu">
+      <Menu mode="horizontal" selectedKeys={[selectedKey]} items={items} />
+    </div>
+  )
+}
+
+export default MobileMenu

--- a/src/styles/_layout.less
+++ b/src/styles/_layout.less
@@ -170,3 +170,35 @@ html.dark-mode .content {
     font-size: 12px;
   }
 }
+
+/* ===== Mobile specific layout ===== */
+.mobile-menu {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.mobile-layout .content {
+  padding-bottom: 60px;
+}
+
+.mobile-menu .ant-menu {
+  display: flex;
+  justify-content: space-around;
+}
+
+.mobile-menu .ant-menu-item {
+  flex: 1;
+  text-align: center;
+}
+
+.light-mode .mobile-menu {
+  background-color: #fff;
+}
+
+.dark-mode .mobile-menu {
+  background-color: #1f1f1f;
+}


### PR DESCRIPTION
## Summary
- add mobile menu component for bottom navigation
- detect screen size in App
- render sidebar or mobile menu based on width
- tweak layout styles for mobile menu

## Testing
- `npm test --silent` *(fails: TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686abfd56cc8832b881bd0fab3346e12