### PR TITLE
Improve budget layout colors

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,11 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #f1f5f9;
 }
 
 code {

--- a/src/styles/_card.less
+++ b/src/styles/_card.less
@@ -4,11 +4,15 @@
 
 .ant-card {
   background-color: #ffffff;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
   width: 100%;
-  max-width: 800px;
+  max-width: 900px;
   padding: 24px;
-  border-radius: 8px;
+  border-radius: 10px;
+  border-top: 4px solid @primary-color;
+  .budget-title {
+    color: @primary-color;
+  }
 
   &-head-title,
   .ant-form-item-label>label {
@@ -63,6 +67,10 @@
   .ant-card {
     background-color: #1f1f1f !important;
     color: #fff;
+    border-top: 4px solid @primary-color;
+    .budget-title {
+      color: @primary-color;
+    }
 
     .ant-form-item-label>label {
       color: #fff !important;

--- a/src/styles/_layout.less
+++ b/src/styles/_layout.less
@@ -20,9 +20,11 @@ html.dark-mode {
 }
 
 /* ===== Sidebar ===== */
+
 .sidebar {
   width: var(--sidebar-width);
-  background-color: @secondary-color;
+  background: linear-gradient(180deg, lighten(@secondary-color, 5%), darken(@secondary-color, 5%));
+  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
   z-index: 10000;
   position: fixed;
   top: 0;

--- a/src/styles/_variables.less
+++ b/src/styles/_variables.less
@@ -1,6 +1,6 @@
-@primary-color: #c19bff;
-@secondary-color: #a784ed;
-@light-background: #8e6edb;
-@dark-background: #5a40b6;
+@primary-color: #6366F1;
+@secondary-color: #4338CA;
+@light-background: #F1F5F9;
+@dark-background: #1E293B;
 @header-height: 80px;
 @sidebar-width: 256px;


### PR DESCRIPTION
## Summary
- refresh color palette
- tweak sidebar with gradient background
- adjust card design for better appearance
- set Inter font and light background
- load Inter from Google Fonts

## Testing
- `npm test` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac594a6dc832b98cf0ae1b79594e2