### PR TITLE
Add category spending goals

### DIFF
--- a/src/components/Budget.js
+++ b/src/components/Budget.js
@@ -36,6 +36,12 @@ const Budget = ({ isDarkMode }) => {
     Educação: [],
     Lazer: []
   })
+  const [categoryGoals, setCategoryGoals] = useState({
+    Moradia: 0,
+    Transporte: 0,
+    Educação: 0,
+    Lazer: 0
+  })
   const [month, setMonth] = useState(null)
   const [totalIncome, setTotalIncome] = useState(0)
   const [totalExpenses, setTotalExpenses] = useState(0)
@@ -108,6 +114,16 @@ const Budget = ({ isDarkMode }) => {
         setSalary(budgetData.salary)
         setApplyDiscount(budgetData.applyDiscount)
         setOtherIncome(budgetData.otherIncome)
+        if (budgetData.categoryGoals) {
+          setCategoryGoals(budgetData.categoryGoals)
+        } else {
+          setCategoryGoals({
+            Moradia: 0,
+            Transporte: 0,
+            Educação: 0,
+            Lazer: 0
+          })
+        }
 
         if (budgetData.expenses) {
           setExpenses(budgetData.expenses)
@@ -143,6 +159,16 @@ const Budget = ({ isDarkMode }) => {
               Lazer: []
             })
           }
+          if (previousBudgetData.categoryGoals) {
+            setCategoryGoals(previousBudgetData.categoryGoals)
+          } else {
+            setCategoryGoals({
+              Moradia: 0,
+              Transporte: 0,
+              Educação: 0,
+              Lazer: 0
+            })
+          }
         } else {
           setExpenses({
             Moradia: [],
@@ -150,11 +176,23 @@ const Budget = ({ isDarkMode }) => {
             Educação: [],
             Lazer: []
           })
+          setCategoryGoals({
+            Moradia: 0,
+            Transporte: 0,
+            Educação: 0,
+            Lazer: 0
+          })
         }
 
         setSalary(0)
         setApplyDiscount(false)
         setOtherIncome(0)
+        setCategoryGoals({
+          Moradia: 0,
+          Transporte: 0,
+          Educação: 0,
+          Lazer: 0
+        })
       }
     } catch (error) {
       console.error('Erro ao recuperar orçamento:', error)
@@ -183,6 +221,12 @@ const Budget = ({ isDarkMode }) => {
         setApplyDiscount(false)
         setOtherIncome(0)
         setExpenses([{ id: uuidv4(), name: '', value: 0, fixed: false }])
+        setCategoryGoals({
+          Moradia: 0,
+          Transporte: 0,
+          Educação: 0,
+          Lazer: 0
+        })
         setMonth(null)
       } catch (error) {
         console.error('Erro ao deletar o documento:', error)
@@ -235,6 +279,13 @@ const Budget = ({ isDarkMode }) => {
     })
   }
 
+  const handleGoalChange = (category, value) => {
+    setCategoryGoals({
+      ...categoryGoals,
+      [category]: value || 0
+    })
+  }
+
   const handleSubmit = async () => {
     if (!month) {
       message.error('Por favor, selecione o mês.')
@@ -256,6 +307,7 @@ const Budget = ({ isDarkMode }) => {
       totalExpenses,
       remainingBalance,
       expenses,
+      categoryGoals,
     }
 
     try {
@@ -358,7 +410,9 @@ const Budget = ({ isDarkMode }) => {
             <div className="expense-list">
               <CategoryExpenseList
                 expenses={expenses}
+                categoryGoals={categoryGoals}
                 handleExpenseChange={handleExpenseChange}
+                handleGoalChange={handleGoalChange}
                 addExpense={addExpense}
                 removeExpense={removeExpense}
                 setExpenses={setExpenses}

--- a/src/components/Budget/CategoryExepenseList.js
+++ b/src/components/Budget/CategoryExepenseList.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { Collapse, Row, Col, Input, InputNumber, Checkbox, Button, Form, message } from 'antd'
 import { PlusOutlined, MinusCircleOutlined, DeleteOutlined } from '@ant-design/icons'
+import CategoryProgressBar from './CategoryProgressBar'
 
 const { Panel } = Collapse
 
@@ -11,7 +12,7 @@ const initialCategories = {
   Lazer: ['Cinema', 'Viagens'],
 }
 
-const CategoryExpenseList = ({ expenses, handleExpenseChange, addExpense, removeExpense, setExpenses }) => {
+const CategoryExpenseList = ({ expenses, categoryGoals, handleExpenseChange, handleGoalChange, addExpense, removeExpense, setExpenses }) => {
   const [categories, setCategories] = useState(initialCategories)
   const [newCategoryName, setNewCategoryName] = useState('')
 
@@ -36,6 +37,10 @@ const CategoryExpenseList = ({ expenses, handleExpenseChange, addExpense, remove
 
   const getCategoryExpenses = (category) => {
     return Array.isArray(expenses[category]) ? expenses[category] : []
+  }
+
+  const getCategoryGoal = (category) => {
+    return categoryGoals && categoryGoals[category] ? categoryGoals[category] : 0
   }
 
   const calculateCategoryTotal = (category) => {
@@ -88,6 +93,21 @@ const CategoryExpenseList = ({ expenses, handleExpenseChange, addExpense, remove
             key={category}
             className="category-panel"
           >
+            <Row gutter={16} style={{ marginBottom: 10 }}>
+              <Col span={12}>
+                <InputNumber
+                  placeholder="Meta"
+                  className="category-goal-input"
+                  value={getCategoryGoal(category)}
+                  onChange={(value) => handleGoalChange(category, value)}
+                  formatter={(value) => `R$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
+                  parser={(value) => value.replace(/R\$\s?|(,*)/g, '')}
+                />
+              </Col>
+              <Col span={12}>
+                <CategoryProgressBar total={calculateCategoryTotal(category)} goal={getCategoryGoal(category)} />
+              </Col>
+            </Row>
             {getCategoryExpenses(category).map((expense, index) => (
               <Row key={expense.id} gutter={16} className="expense-row">
                 <Col xs={24} md={8}>

--- a/src/components/Budget/CategoryProgressBar.js
+++ b/src/components/Budget/CategoryProgressBar.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import { Progress } from 'antd'
+
+const CategoryProgressBar = ({ total, goal }) => {
+  const percent = goal > 0 ? Math.min((total / goal) * 100, 100) : 0
+  const status = total > goal ? 'exception' : 'active'
+  return <Progress percent={Math.round(percent)} status={status} />
+}
+
+export default CategoryProgressBar

--- a/src/styles/_budget.less
+++ b/src/styles/_budget.less
@@ -56,6 +56,11 @@
   border-radius: 8px;
 }
 
+.category-goal-input {
+  width: 100%;
+  border-radius: 8px;
+}
+
 // =============================
 // MODO ESCURO
 // =============================
@@ -131,6 +136,12 @@
     border-color: #555 !important;
   }
 
+  .category-goal-input {
+    background-color: #2a2a2a !important;
+    color: #fff !important;
+    border-color: #555 !important;
+  }
+
   .expense-add-button {
     background-color: #2a2a2a;
     color: #fff;
@@ -187,6 +198,11 @@
   }
 
   .new-category-input {
+    width: 100%;
+    font-size: 15px;
+  }
+
+  .category-goal-input {
     width: 100%;
     font-size: 15px;
   }

--- a/src/styles/_categoryExpenseList.less
+++ b/src/styles/_categoryExpenseList.less
@@ -40,6 +40,11 @@
   border-radius: 8px;
 }
 
+.category-goal-input {
+  width: 100%;
+  border-radius: 8px;
+}
+
 @media (max-width: 420px) {
   .category-panel {
     padding: 10px;


### PR DESCRIPTION
## Summary
- add `CategoryProgressBar` component
- add state for category goals
- show progress bar and goal input for each category
- style the new goal input

## Testing
- `npx craco test --silent` *(fails: TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686ad0a20070832b8709eca7cae6b267